### PR TITLE
Update changelog-checker to use celestiaorg fork

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Checkout source code"
         uses: "actions/checkout@v2"
       - name: Changelog check
-        uses: Zomzog/changelog-checker@v1.2.0
+        uses: celestiaorg/changelog-checker@v1
         with:
           fileName: CHANGELOG.md
           checkNotification: Simple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+
+## [Unreleased]
+
+- Update `.github/workflows/changelog-checker.yml` to use the fork `celestiaorg/changelog-checker@v1`


### PR DESCRIPTION
I created a fork of [Zomzog's changelog-checker](https://github.com/Zomzog/changelog-checker) at [celestiaorg/changelog-checker](https://github.com/celestiaorg/changelog-checker) so that we can more easily maintain any changes we want to make to it. 

This PR updates the changelog-checker action to use this fork. 