### PR TITLE
Update docker images to use Ubuntu instead of Alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `celestia-app` subdir to `/devnet` with `Dockerfile` and other config files for a 4 node network
 - Add `celestia-node` subdir to `/devnet` with `Dockerfile` and other config files for a 2 (full) node network connecting to the above `celestia-app` network
 - Add `docker` directory to `/devnet` with several `docker-compose.yml` files to automate creation of above networks
+- Update `celestia-app` and `celestia-node` docker images to base off Ubuntu instead of Alpine

--- a/devnet/celestia-app/Dockerfile
+++ b/devnet/celestia-app/Dockerfile
@@ -1,10 +1,6 @@
-# TODO: We probably don't need golang anymore
-FROM alpine
+FROM ubuntu
 
-# Because Alpine
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-RUN apk update && \
-    apk --no-cache add bash
+RUN apt update
 
 ENV APP /celestia-app
 WORKDIR $APP

--- a/devnet/celestia-node/Dockerfile
+++ b/devnet/celestia-node/Dockerfile
@@ -1,9 +1,6 @@
-FROM alpine
+FROM ubuntu 
 
-# Because Alpine
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-RUN apk update && \
-    apk --no-cache add bash
+RUN apt update
 
 ENV APP /celestia-full
 WORKDIR $APP
@@ -16,8 +13,6 @@ EXPOSE 2121
 RUN [ "/bin/bash", "-c", "exec ./celestia \
     full --repo.path ${APP} init" ]
 
-# This allows us to always set the --home directory using an env 
-# var while still capturing all argumenmts passed at runtime
 ENTRYPOINT [ "/bin/bash", "-c", "sleep 2 && \ 
             exec ./celestia \
             \"${@}\"", "--" ]

--- a/devnet/docker/docker-compose-full-node.yml
+++ b/devnet/docker/docker-compose-full-node.yml
@@ -79,8 +79,7 @@ services:
             "--core.remote", 
             "tcp://192.167.10.2:26657",
             "--headers.trusted-hash", 
-            "A9272DAD1BEBEF104EBDBF071E39789E21C0650AF5B76A7062213B772B6B925E",
-            "--log.level", "debug"
+            "A9272DAD1BEBEF104EBDBF071E39789E21C0650AF5B76A7062213B772B6B925E"
              ]
     volumes:
        - ${PWD}/celestia-node/full0/nodekey0:/celestia-full/keys/OAZHALLLMV4Q:ro
@@ -99,8 +98,7 @@ services:
             "--core.remote", 
             "tcp://192.167.10.3:26657",
             "--headers.trusted-hash", 
-            "A9272DAD1BEBEF104EBDBF071E39789E21C0650AF5B76A7062213B772B6B925E",
-            "--log.level", "debug"
+            "A9272DAD1BEBEF104EBDBF071E39789E21C0650AF5B76A7062213B772B6B925E"
              ]
     volumes:
        - ${PWD}/celestia-node/full1/nodekey1:/celestia-full/keys/OAZHALLLMV4Q:ro


### PR DESCRIPTION
Docker images for `celestia-app` and `celestia-node` should use Ubuntu for the time being as running on Alpine sometimes has issues. 