### PR TITLE
Update docker-compose w/ more full node volume mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Hardcode core + full pod IPs utilizing Calico CNI IPAM to allow for persistent p2p connections.
 - Add devnet/k8s/README.md with instructions for setting up minimum viable k8s cluster
 - Update minikube GH action to standup Minimum Viable Cluster (MVC) and test that core nodes produce a block
+- Update docker-compose to take genesis.json file and gentx/ dir as volume mounts

--- a/devnet/docker/docker-compose.yml
+++ b/devnet/docker/docker-compose.yml
@@ -9,11 +9,14 @@ services:
             "--p2p.persistent_peers",
             "ffdc6d353abf0c53f35fbfe1106dc216121e1d17@192.167.10.3:26656",
             "9908b74112720aedabb79909fa21a2d7e59a38be@192.167.10.4:26656",
-            "c4c8024a2447f08136a6a9b10515232114011ecd@192.167.10.5:26656" 
+            "c4c8024a2447f08136a6a9b10515232114011ecd@192.167.10.5:26656",
+            "--rpc.laddr", "tcp://0.0.0.0:26657"
         ]
     volumes:
        - ${PWD}/celestia-app/node0/app/config/priv_validator_key.json:/celestia-app/config/priv_validator_key.json:ro
        - ${PWD}/celestia-app/node0/app/config/node_key.json:/celestia-app/config/node_key.json:ro
+       - ${PWD}/celestia-app/golden-genesis.json:/celestia-app/config/genesis.json:ro
+       - ${PWD}/celestia-app/gentx:/celestia-app/config/gentx:ro
     networks:
       localnet:
         ipv4_address: 192.167.10.2
@@ -26,11 +29,14 @@ services:
             "--p2p.persistent_peers",
             "d78ad9583f27cc73738f246b93186e40cc0272e4@192.167.10.2:26656",
             "9908b74112720aedabb79909fa21a2d7e59a38be@192.167.10.4:26656",
-            "c4c8024a2447f08136a6a9b10515232114011ecd@192.167.10.5:26656"
+            "c4c8024a2447f08136a6a9b10515232114011ecd@192.167.10.5:26656",
+            "--rpc.laddr", "tcp://0.0.0.0:26657"
             ]
     volumes:
        - ${PWD}/celestia-app/node1/app/config/priv_validator_key.json:/celestia-app/config/priv_validator_key.json:ro
        - ${PWD}/celestia-app/node1/app/config/node_key.json:/celestia-app/config/node_key.json:ro
+       - ${PWD}/celestia-app/golden-genesis.json:/celestia-app/config/genesis.json:ro
+       - ${PWD}/celestia-app/gentx:/celestia-app/config/gentx:ro
     networks:
       localnet:
         ipv4_address: 192.167.10.3
@@ -43,11 +49,14 @@ services:
             "--p2p.persistent_peers",
             "d78ad9583f27cc73738f246b93186e40cc0272e4@192.167.10.2:26656",
             "ffdc6d353abf0c53f35fbfe1106dc216121e1d17@192.167.10.3:26656",
-            "c4c8024a2447f08136a6a9b10515232114011ecd@192.167.10.5:26656"
+            "c4c8024a2447f08136a6a9b10515232114011ecd@192.167.10.5:26656",
+            "--rpc.laddr", "tcp://0.0.0.0:26657"
              ]
     volumes:
        - ${PWD}/celestia-app/node2/app/config/priv_validator_key.json:/celestia-app/config/priv_validator_key.json:ro
        - ${PWD}/celestia-app/node2/app/config/node_key.json:/celestia-app/config/node_key.json:ro
+       - ${PWD}/celestia-app/golden-genesis.json:/celestia-app/config/genesis.json:ro
+       - ${PWD}/celestia-app/gentx:/celestia-app/config/gentx:ro
     networks:
       localnet:
         ipv4_address: 192.167.10.4
@@ -61,10 +70,13 @@ services:
             "d78ad9583f27cc73738f246b93186e40cc0272e4@192.167.10.2:26656",
             "ffdc6d353abf0c53f35fbfe1106dc216121e1d17@192.167.10.3:26656",
             "9908b74112720aedabb79909fa21a2d7e59a38be@192.167.10.4:26656",
+            "--rpc.laddr", "tcp://0.0.0.0:26657"
              ]
     volumes:
        - ${PWD}/celestia-app/node3/app/config/priv_validator_key.json:/celestia-app/config/priv_validator_key.json:ro
        - ${PWD}/celestia-app/node3/app/config/node_key.json:/celestia-app/config/node_key.json:ro
+       - ${PWD}/celestia-app/golden-genesis.json:/celestia-app/config/genesis.json:ro
+       - ${PWD}/celestia-app/gentx:/celestia-app/config/gentx:ro
     networks:
       localnet:
         ipv4_address: 192.167.10.5

--- a/devnet/docker/docker-compose.yml
+++ b/devnet/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  node0:
+  core0:
     container_name: core0
     image: "jbowen93/celestia-app:devnet"
     command: [
@@ -21,7 +21,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.2
 
-  node1:
+  core1:
     container_name: core1
     image: "jbowen93/celestia-app:devnet"
     command: [
@@ -41,7 +41,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.3
 
-  node2:
+  core2:
     container_name: core2
     image: "jbowen93/celestia-app:devnet"    
     command: [
@@ -61,7 +61,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.4
 
-  node3:
+  core3:
     container_name: core3
     image: "jbowen93/celestia-app:devnet"
     command: [
@@ -81,7 +81,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.5
 
-  full-node0:
+  full0:
     container_name: full0
     image: "jbowen93/celestia-node-full:devnet"
     command: [
@@ -99,7 +99,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.6
 
-  full-node1:
+  full1:
     container_name: full1
     image: "jbowen93/celestia-node-full:devnet"
     command: [
@@ -117,7 +117,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.7
 
-  full-node2:
+  full2:
     container_name: full2
     image: "jbowen93/celestia-node-full:devnet"
     command: [
@@ -135,7 +135,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.8
 
-  full-node3:
+  full3:
     container_name: full3
     image: "jbowen93/celestia-node-full:devnet"
     command: [
@@ -153,7 +153,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.9
 
-  light-node0:
+  light0:
     container_name: light0
     image: "jbowen93/celestia-node-light:devnet"
     command: [
@@ -171,7 +171,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.10
 
-  light-node1:
+  light1:
     container_name: light1
     image: "jbowen93/celestia-node-light:devnet"
     command: [
@@ -189,7 +189,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.11
         
-  light-node2:
+  light2:
     container_name: light2
     image: "jbowen93/celestia-node-light:devnet"
     command: [
@@ -207,7 +207,7 @@ services:
       localnet:
         ipv4_address: 192.167.10.12
 
-  light-node3:
+  light3:
     container_name: light3
     image: "jbowen93/celestia-node-light:devnet"
     command: [


### PR DESCRIPTION
Update docker-compose so that the full nodes now take both the `genesis.json` file and the `gentx/` directory as volume mounts. Previously they were expected to be baked into the Docker image.
