### PR TITLE
Update k8s configs to use new docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add devnet/k8s/README.md with instructions for setting up minimum viable k8s cluster
 - Update minikube GH action to standup Minimum Viable Cluster (MVC) and test that core nodes produce a block
 - Update docker-compose to take genesis.json file and gentx/ dir as volume mounts
+- Update k8s/ config files to use new docker images created in PRs ([#163](https://github.com/celestiaorg/celestia-app/pull/163)) and ([#295](https://github.com/celestiaorg/celestia-node/pull/295))

--- a/devnet/k8s/core-nodes/0/core0-deployment.yaml
+++ b/devnet/k8s/core-nodes/0/core0-deployment.yaml
@@ -33,7 +33,7 @@ spec:
               mountPath: /celestia-full/keys/
       containers:
         - name: celestia-app
-          image: jbowen93/celestia-app:devnet-volumes
+          image: jbowen93/celestia-app:multi
           args: ["start", "--p2p.persistent_peers",
                 "$(CORE1)",
                 "$(CORE2)",
@@ -72,11 +72,12 @@ spec:
             subPath: genesis.json
           - name: gentx-volume
             mountPath: /celestia-app/config/gentx
-
           resources: {}
         - name: celestia-node
-          image: jbowen93/celestia-node-full:devnet-no-sleep
+          image: jbowen93/celestia-node:multi
           args:
+            - celestia
+            - full
             - --repo.path
             - /celestia-full
             - start
@@ -84,6 +85,9 @@ spec:
             - tcp://127.0.0.1:26657
             - --headers.trusted-hash
             - 64D831D041A57A9D93078B445F7B1347024A9B5A8A444086C0B556B65A8A96C7
+          env:
+            - name: NODE_TYPE
+              value: full
           volumeMounts:
             - name: full0-nodekey-volume
               mountPath: /celestia-full/keys/OAZHALLLMV4Q

--- a/devnet/k8s/core-nodes/0/core0-node-key-configmap.yaml
+++ b/devnet/k8s/core-nodes/0/core0-node-key-configmap.yaml
@@ -3,8 +3,5 @@ data:
   node_key.json: '{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"RCoVQiWhUfs+s1D2BKf3O1gEQ8rilOFhUowbQr4a5eNkWOsfmtYwsI1m+4rv++iZ762EHVaoKjDaPh/X4UPYgQ=="}}'
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-10T19:25:19Z"
   name: core0-node-key
   namespace: default
-  resourceVersion: "128140"
-  uid: edd9a562-f6dd-4530-a88d-09fa9e0452b6

--- a/devnet/k8s/core-nodes/0/core0-validator-key-configmap.yaml
+++ b/devnet/k8s/core-nodes/0/core0-validator-key-configmap.yaml
@@ -14,8 +14,6 @@ data:
     }
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-10T19:25:00Z"
   name: core0-validator-key
   namespace: default
-  resourceVersion: "128125"
-  uid: 3cba4125-76c0-48ea-9f1a-272930121c4f
+

--- a/devnet/k8s/core-nodes/1/core1-deployment.yaml
+++ b/devnet/k8s/core-nodes/1/core1-deployment.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /celestia-full/keys/
       containers:
         - name: celestia-app
-          image: jbowen93/celestia-app:devnet-volumes
+          image: jbowen93/celestia-app:multi
           args: ["start", "--p2p.persistent_peers",
                 "$(CORE0)",
                 "$(CORE2)",
@@ -80,8 +80,10 @@ spec:
                 command: ["/bin/sh", "-c", "sleep 25"]
           resources: {}
         - name: celestia-node
-          image: jbowen93/celestia-node-full:devnet-no-sleep
+          image: jbowen93/celestia-node:multi
           args:
+            - celestia
+            - full
             - --repo.path
             - /celestia-full
             - start
@@ -89,6 +91,9 @@ spec:
             - tcp://127.0.0.1:26657
             - --headers.trusted-hash
             - 64D831D041A57A9D93078B445F7B1347024A9B5A8A444086C0B556B65A8A96C7
+          env:
+            - name: NODE_TYPE
+              value: full
           volumeMounts:
             - name: full1-nodekey-volume
               mountPath: /celestia-full/keys/OAZHALLLMV4Q

--- a/devnet/k8s/core-nodes/1/core1-node-key-configmap.yaml
+++ b/devnet/k8s/core-nodes/1/core1-node-key-configmap.yaml
@@ -3,8 +3,5 @@ data:
   node_key.json: '{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"tKg5mzI1lYC+NkBYcUSQ0GYGVfNwHYrlR6/oUKLL6aLSVrSpoSXFORjLMO+p9Edh26/IDV/vS3Oy0R2yT49FJw=="}}'
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-10T19:34:37Z"
   name: core1-node-key
   namespace: default
-  resourceVersion: "128594"
-  uid: 300d1605-a60e-4a18-b7bc-d6f2d7e303d1

--- a/devnet/k8s/core-nodes/1/core1-validator-key-configmap.yaml
+++ b/devnet/k8s/core-nodes/1/core1-validator-key-configmap.yaml
@@ -14,8 +14,5 @@ data:
     }
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-10T19:36:44Z"
   name: core1-validator-key
   namespace: default
-  resourceVersion: "128689"
-  uid: 5594b901-a180-451d-878f-ab0d01c40ee1

--- a/devnet/k8s/core-nodes/2/core2-deployment.yaml
+++ b/devnet/k8s/core-nodes/2/core2-deployment.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /celestia-full/keys/
       containers:
         - name: celestia-app
-          image: jbowen93/celestia-app:devnet-volumes
+          image: jbowen93/celestia-app:multi
           args: ["start", "--p2p.persistent_peers",
                 "$(CORE0)",
                 "$(CORE1)",
@@ -80,8 +80,10 @@ spec:
                 command: ["/bin/sh", "-c", "sleep 25"]
           resources: {}
         - name: celestia-node
-          image: jbowen93/celestia-node-full:devnet-no-sleep
+          image: jbowen93/celestia-node:multi
           args:
+            - celestia
+            - full
             - --repo.path
             - /celestia-full
             - start
@@ -89,6 +91,9 @@ spec:
             - tcp://127.0.0.1:26657
             - --headers.trusted-hash
             - 64D831D041A57A9D93078B445F7B1347024A9B5A8A444086C0B556B65A8A96C7
+          env:
+            - name: NODE_TYPE
+              value: full
           volumeMounts:
             - name: full2-nodekey-volume
               mountPath: /celestia-full/keys/OAZHALLLMV4Q

--- a/devnet/k8s/core-nodes/2/core2-node-key-configmap.yaml
+++ b/devnet/k8s/core-nodes/2/core2-node-key-configmap.yaml
@@ -3,8 +3,6 @@ data:
   node_key.json: '{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"2qpWRJizEL9Vxuky4oS1h7Bo7eUCWJsBaZUIWuinysY4jy2VcUube1qGf9oLIsZuj4dj0iw6YPmA8mnvyRN5nA=="}}'
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-10T19:34:51Z"
   name: core2-node-key
   namespace: default
-  resourceVersion: "128604"
-  uid: d2fd23fc-e3aa-4a92-9153-3d2a50e251fb
+

--- a/devnet/k8s/core-nodes/2/core2-validator-key-configmap.yaml
+++ b/devnet/k8s/core-nodes/2/core2-validator-key-configmap.yaml
@@ -14,8 +14,5 @@ data:
     }
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-10T19:36:55Z"
   name: core2-validator-key
   namespace: default
-  resourceVersion: "128697"
-  uid: 3edf7a02-fcea-4847-9ebb-74a72775974a

--- a/devnet/k8s/core-nodes/2/full2-nodekey-configmap.yaml
+++ b/devnet/k8s/core-nodes/2/full2-nodekey-configmap.yaml
@@ -3,8 +3,5 @@ data:
   nodekey2: '{"body":"CAESQPffF6Bl1xr1+zDYq6kuCdYcgIP0z9/71qX8e7CGJRfF1bWgtWAjpQcUO1nqdl8kfH9Qq8OYxnPzoA1cIppXpx4="}'
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-14T17:44:52Z"
   name: full2-nodekey
   namespace: default
-  resourceVersion: "29394"
-  uid: 5c2f06f2-56fe-4108-bc54-aea4cefdbf5c

--- a/devnet/k8s/core-nodes/3/core3-deployment.yaml
+++ b/devnet/k8s/core-nodes/3/core3-deployment.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /celestia-full/keys/
       containers:
         - name: celestia-app
-          image: jbowen93/celestia-app:devnet-volumes
+          image: jbowen93/celestia-app:multi
           args: ["start", "--p2p.persistent_peers",
                 "$(CORE0)",
                 "$(CORE1)",
@@ -80,8 +80,10 @@ spec:
                 command: ["/bin/sh", "-c", "sleep 25"]
           resources: {}
         - name: celestia-node
-          image: jbowen93/celestia-node-full:devnet-no-sleep
+          image: jbowen93/celestia-node:multi
           args:
+            - celestia
+            - full
             - --repo.path
             - /celestia-full
             - start
@@ -89,6 +91,9 @@ spec:
             - tcp://127.0.0.1:26657
             - --headers.trusted-hash
             - 64D831D041A57A9D93078B445F7B1347024A9B5A8A444086C0B556B65A8A96C7
+          env:
+            - name: NODE_TYPE
+              value: full
           volumeMounts:
             - name: full3-nodekey-volume
               mountPath: /celestia-full/keys/OAZHALLLMV4Q

--- a/devnet/k8s/core-nodes/3/core3-node-key-configmap.yaml
+++ b/devnet/k8s/core-nodes/3/core3-node-key-configmap.yaml
@@ -3,8 +3,5 @@ data:
   node_key.json: '{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"0wd0S11L5GaSJ+a9TvBqARHt7sD31WMESE25PG5xnMp4H6C1olQCb6rJsAnBXyXluHbFh1e8MH81Q/aqDKMMSw=="}}'
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-10T19:35:02Z"
   name: core3-node-key
   namespace: default
-  resourceVersion: "128612"
-  uid: ef5eca62-e3a8-48b5-b2fa-115a54ae5914

--- a/devnet/k8s/core-nodes/3/core3-validator-key-configmap.yaml
+++ b/devnet/k8s/core-nodes/3/core3-validator-key-configmap.yaml
@@ -14,8 +14,5 @@ data:
     }
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-10T19:37:04Z"
   name: core3-validator-key
   namespace: default
-  resourceVersion: "128705"
-  uid: 01617aff-50e8-401d-a91d-2725238d9492

--- a/devnet/k8s/core-nodes/3/full3-nodekey-configmap.yaml
+++ b/devnet/k8s/core-nodes/3/full3-nodekey-configmap.yaml
@@ -3,8 +3,5 @@ data:
   nodekey3: '{"body":"CAESQAyGOmHnku2IIGQ3X6I4MpjEe/9Bhy0O5cne6hI5EBRzBD0R02D8//wGmHCaLrwoqSIcHiGm/XzqWxkUeLXQ3EU="}'
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2021-12-14T17:45:03Z"
   name: full3-nodekey
   namespace: default
-  resourceVersion: "29403"
-  uid: 24504660-dd67-4289-8d99-872086b7a357

--- a/devnet/k8s/light-nodes/0/light-node0-deployment.yaml
+++ b/devnet/k8s/light-nodes/0/light-node0-deployment.yaml
@@ -29,8 +29,9 @@ spec:
               mountPath: /celestia-light/keys/
       containers:
         - name: light0
-          image: jbowen93/celestia-node-light:devnet-no-sleep
+          image: jbowen93/celestia-node:multi
           args: [
+            "celestia", "light",
             "--repo.path", "/celestia-light",
             "start",
             "--headers.trusted-peer", 
@@ -38,6 +39,9 @@ spec:
             "--headers.trusted-hash",
             "64D831D041A57A9D93078B445F7B1347024A9B5A8A444086C0B556B65A8A96C7"
           ]
+          env:
+            - name: NODE_TYPE
+              value: light
           volumeMounts:
             - name: light0-nodekey-volume
               mountPath: /celestia-light/keys/OAZHALLLMV4Q

--- a/devnet/k8s/light-nodes/1/light-node1-deployment.yaml
+++ b/devnet/k8s/light-nodes/1/light-node1-deployment.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: light1
-      annotations:
     spec:
       initContainers:
         - name: set-nodekey-permissions
@@ -30,8 +29,9 @@ spec:
               mountPath: /celestia-light/keys/
       containers:
         - name: light1
-          image: jbowen93/celestia-node-light:devnet-no-sleep
+          image: jbowen93/celestia-node:multi
           args: [
+            "celestia", "light",
             "--repo.path", "/celestia-light",
             "start",
             "--headers.trusted-peer", 
@@ -39,6 +39,9 @@ spec:
             "--headers.trusted-hash",
             "64D831D041A57A9D93078B445F7B1347024A9B5A8A444086C0B556B65A8A96C7"
           ]
+          env:
+            - name: NODE_TYPE
+              value: light
           volumeMounts:
             - name: light1-nodekey-volume
               mountPath: /celestia-light/keys/OAZHALLLMV4Q

--- a/devnet/k8s/light-nodes/2/light-node2-deployment.yaml
+++ b/devnet/k8s/light-nodes/2/light-node2-deployment.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: light2
-      annotations:
     spec:
       initContainers:
         - name: set-nodekey-permissions
@@ -30,8 +29,9 @@ spec:
               mountPath: /celestia-light/keys/
       containers:
         - name: light2
-          image: jbowen93/celestia-node-light:devnet-no-sleep
+          image: jbowen93/celestia-node:multi
           args: [
+            "celestia", "light",
             "--repo.path", "/celestia-light",
             "start",
             "--headers.trusted-peer", 
@@ -39,6 +39,9 @@ spec:
             "--headers.trusted-hash",
             "64D831D041A57A9D93078B445F7B1347024A9B5A8A444086C0B556B65A8A96C7"
           ]
+          env:
+            - name: NODE_TYPE
+              value: light
           volumeMounts:
             - name: light2-nodekey-volume
               mountPath: /celestia-light/keys/OAZHALLLMV4Q

--- a/devnet/k8s/light-nodes/3/light-node3-deployment.yaml
+++ b/devnet/k8s/light-nodes/3/light-node3-deployment.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: light3
-      annotations:
     spec:
       initContainers:
         - name: set-nodekey-permissions
@@ -30,8 +29,9 @@ spec:
               mountPath: /celestia-light/keys/
       containers:
         - name: light3
-          image: jbowen93/celestia-node-light:devnet-no-sleep
+          image: jbowen93/celestia-node:multi
           args: [
+            "celestia", "light",
             "--repo.path", "/celestia-light",
             "start",
             "--headers.trusted-peer", 
@@ -39,6 +39,9 @@ spec:
             "--headers.trusted-hash",
             "64D831D041A57A9D93078B445F7B1347024A9B5A8A444086C0B556B65A8A96C7"
           ]
+          env:
+            - name: NODE_TYPE
+              value: light
           volumeMounts:
             - name: light3-nodekey-volume
               mountPath: /celestia-light/keys/OAZHALLLMV4Q


### PR DESCRIPTION
Update the k8s/ dir to use the new Docker images created in PRs:
- celestia-app ([#163](https://github.com/celestiaorg/celestia-app/pull/163))
- celestia-node ([#295](https://github.com/celestiaorg/celestia-node/pull/295))


Tested manually with
```
kubectl create -f devnet/k8s/core-nodes -R && sleep 45 && kubectl create -f devnet/k8s/light-nodes -R
```