### PR TITLE
Fix broken pre-release GH action

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          context: hello
           push: true
           tags: ghcr.io/celestiaorg/devops-test:latest
       - uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   pre-release:
     runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        shell: bash
+        working-directory: hello
     permissions:
       contents: write 
       packages: write 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,4 +38,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update k8s/ config files to use new docker images created in PRs ([#163](https://github.com/celestiaorg/celestia-app/pull/163)) and ([#295](https://github.com/celestiaorg/celestia-node/pull/295))
 - Split devnet/docker/docker-compose.yml into 3 files, one for each node type
 - Create devnet/README.md which contains instructions for utilizing both the docker-compose and K8s dev clusters
-- Replace config.toml files with `--p2p.mutual` in bridge nodes and remove unneeded config.toml files in light nodes.
+- Replace config.toml files with `--p2p.mutual` in bridge nodes and remove unneeded config.toml files in light nodes
+- Fix broken pre-release GH action by running it on the `/hello` dir


### PR DESCRIPTION
The pre-release Github action was broken when this repo was refactored and the original code was moved to the `/hello` dir. This PR runs the GH action on the aforementioned `/hello` dir.